### PR TITLE
Mark in plugin.xml that CF does support remote hosts

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.branding/plugin.xml
+++ b/org.cloudfoundry.ide.eclipse.server.branding/plugin.xml
@@ -33,6 +33,7 @@
 	        description="Publishes and runs J2EE Web projects to Cloud Foundry."
 	        hasConfiguration="false"
 	        id="org.cloudfoundry.appcloudserver.10"
+            supportsRemoteHosts="true"
 	        initialState="stopped"
 	        name="Cloud Foundry"
 	        runtime="true"


### PR DESCRIPTION
I've got a CloudFoundry installation of my own, but not on my local machine. I tried pointing STS to that installation in the "new server" dialog, selecting a Cloud Foundry server type, but got an error "The currently selected server type does not support remote hosts" when typing in its API URL (I configured it to api.vcap.me and added a /etc/hosts entry on my machine).

This commit fixes this issue by simply declaring that CF _does_ support remote hosts in the plugin.xml server type entry.
I made a build of the plugin and verified that thusly "added" remote host support is working correctly.
