### PR TITLE
Upgrading version of tycho to 0.18.1 so that it works with maven 3.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <test.useUIThread>true</test.useUIThread>
     <test.skip>${maven.test.skip}</test.skip>
 
-    <tycho-version>0.16.0</tycho-version>
+    <tycho-version>0.18.1</tycho-version>
 
     <maven.test.error.ignore>true</maven.test.error.ignore>
     <maven.test.failure.ignore>true</maven.test.failure.ignore>


### PR DESCRIPTION
With maven version 3.2.1, running mavn package =Pe37 returns a methodNotFound exception.
