### PR TITLE
Fix a bug when dragging and dropping a local project into the applicat...

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryServerBehaviour.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryServerBehaviour.java
@@ -1293,6 +1293,25 @@ public class CloudFoundryServerBehaviour extends ServerBehaviourDelegate {
 		return Status.OK_STATUS;
 	}
 
+        /**
+	 * Judges whether there is a <code>CloudFoundryApplicationModule</code> with the given name 
+	 * in current server or not.
+	 * 
+	 * @param moduleName the module name to be checked
+	 * @return true if there is a <code>CloudFoundryApplicationModule</code> with the 
+	 *     given name in current server, false otherwise
+	 */
+	public boolean existCloudApplicationModule(String moduleName) {
+		List<IModule[]> allModules = getAllModules();
+		for (IModule[] modules : allModules) {
+			if (modules[0] instanceof CloudFoundryApplicationModule 
+			    && modules[0].getName().equals(moduleName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	protected void handlePublishError(CoreException e) {
 		// Do not automatically delete apps on errors, even
 		// if critical errors


### PR DESCRIPTION
...ionViewer.

If there is already a cloud application with the same name as the local project, the cloud application will be deleted and replaced by the local project, which is "not yet deployed". 

_Fig1_ drag and drop local project with the same name
![drag&drop](https://cloud.githubusercontent.com/assets/7316500/4006332/71af4820-29a8-11e4-96bc-e2fd9dc42aae.PNG)

_Fig2_ existed cloud application is replaced
![replaced](https://cloud.githubusercontent.com/assets/7316500/4006543/87b5025e-29ad-11e4-81f8-85b10d4e603b.PNG)

There should better be a warning message and not delete the cloud application which already exists.

_Fig3_ better jump out a warning message
![warning](https://cloud.githubusercontent.com/assets/7316500/4006594/9225eb8e-29af-11e4-805e-772ffed8c37a.PNG)
