### PR TITLE
Fix a bug of updating URI when adding a route to an existing app

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/editor/ApplicationDetailsPart.java
+++ b/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/editor/ApplicationDetailsPart.java
@@ -747,6 +747,7 @@ public class ApplicationDetailsPart extends AbstractFormPart implements IDetails
 							generalSection.getParent().layout(true, true);
 							editorPage.reflow();
 							application.setUris(URIs);
+							appModule.setCloudApplication(application);
 						}
 					}
 				}


### PR DESCRIPTION
The steps below can re-produce the problem:
- Drag and drop a local project into the application viewer, using the name (for example 'phpdemo') which exists in another account.
  ![bugfix20140922_pushappwithnameusedbyotheruser](https://cloud.githubusercontent.com/assets/7316500/4368938/05fcbe12-42f5-11e4-9063-9e09bdcb5718.PNG)
  Then it shows the name has been token:
  ![bugfix20140922_showhostistaken](https://cloud.githubusercontent.com/assets/7316500/4368984/ae07942e-42f5-11e4-8cd4-11c25186e7a5.PNG)
- Select the application which just failed to push, press the 'edit' icon in the 'General' section, and add a new route through the jump-out dialog.
  ![bugfix20140922_addnewuri](https://cloud.githubusercontent.com/assets/7316500/4369000/05474572-42f6-11e4-8390-a6c5790343f4.PNG)
  ![bugfix20140922_addnewuri02](https://cloud.githubusercontent.com/assets/7316500/4369001/0b682494-42f6-11e4-82d4-22e45726f065.PNG)
- Now the new route is connected to the selected application
  ![bugfix20140922_addnewuri03](https://cloud.githubusercontent.com/assets/7316500/4369021/55b795b6-42f6-11e4-9ca1-a325f86484da.PNG)
  It also shows the target application is bound with the new route via CFCLI:
  ![bugfix20140922_addnewuri04](https://cloud.githubusercontent.com/assets/7316500/4369023/5a322d72-42f6-11e4-9fe0-e6162404b995.PNG)
- Press 'Start' button for the first time, and an error dialog shows the application has no mapped url. (**Here is the bug existing**)
  ![bugfix20140922_start1stshowerror](https://cloud.githubusercontent.com/assets/7316500/4369060/e28095e2-42f6-11e4-926a-968457d9513a.PNG)
- If close the error dialog, press 'Start' button again, then the application can be pushed successfully because the URI has been updated when error above happens. So we can fix the bug by adding one line code to update app info immediately after setting URI.
  ![bugfix20140922_start2ndpushsuccessfully](https://cloud.githubusercontent.com/assets/7316500/4369071/0aa2e34a-42f7-11e4-9c49-37578204d9be.PNG)
