### PR TITLE
All the bound cloud applications are re-pushed if deleting one bound pro...

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryCallback.java
@@ -124,4 +124,13 @@ public abstract class CloudFoundryCallback {
 
 	}
 
+	/**
+	 * Shows a confirmation dialog with the given operation title and message, and
+	 * asks the user the determine whether to execute the target operation.
+	 * 
+	 * @param title the title of the target operation
+	 * @param message the message presented to the user
+	 * @return true if the user chooses to execute the target operation, false otherwise
+	 */
+	public abstract boolean confirmTheOperation(final String title, final String message);
 }

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryPlugin.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryPlugin.java
@@ -218,6 +218,12 @@ public class CloudFoundryPlugin extends Plugin {
 			// TODO Auto-generated method stub
 
 		}
+
+		@Override
+		public boolean confirmTheOperation(String title, String message) {
+			// ignore
+			return false;
+		}
 	}
 
 	private static class AppStateTrackerEntry {

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.java
@@ -185,6 +185,10 @@ public class Messages extends NLS {
 
 	public static String ModuleResourceApplicationArchive_ERROR_NO_DEPLOYABLE_RES_FOUND;
 
+	public static String REPUSH_CLOUD_APP_CONFIRMATION_TITLE;
+	
+	public static String REPUSH_CLOUD_APP_CONFIRMATION_MESSAGE;
+
 	private static final String BUNDLE_NAME = CloudFoundryPlugin.PLUGIN_ID + ".internal.Messages"; //$NON-NLS-1$
 
 	static {

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.properties
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.properties
@@ -102,3 +102,5 @@ ROUTES=Getting routes for domain - {0}
 EMPTY_URL_ERROR=Enter a deployment URL
 JavaWebApplicationDelegate_ERROR_NO_MAPPED_APP_URL=No mapped application URLs set in application deployment information.
 ModuleResourceApplicationArchive_ERROR_NO_DEPLOYABLE_RES_FOUND=Unable to deploy module. No deployable resources found for module: {0} with id: {1}
+REPUSH_CLOUD_APP_CONFIRMATION_TITLE=Confirm to repush cloud application
+REPUSH_CLOUD_APP_CONFIRMATION_MESSAGE=Are you sure to repush the bound cloud application {0} ?

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryServerBehaviour.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryServerBehaviour.java
@@ -1372,7 +1372,9 @@ public class CloudFoundryServerBehaviour extends ServerBehaviourDelegate {
 					// publish
 					op = new PushApplicationOperation(module);
 				}
-				else if (deltaKind == ServerBehaviourDelegate.CHANGED) {
+				else if (deltaKind == ServerBehaviourDelegate.CHANGED && CloudFoundryPlugin.getCallback()
+					.confirmTheOperation(Messages.REPUSH_CLOUD_APP_CONFIRMATION_TITLE, 
+					    NLS.bind(Messages.REPUSH_CLOUD_APP_CONFIRMATION_MESSAGE, module[0].getName()))) {
 					op = getApplicationOperation(module, ApplicationAction.UPDATE_RESTART);
 				}
 				// Republish the root module if any of the child module requires

--- a/org.cloudfoundry.ide.eclipse.server.tests/src/org/cloudfoundry/ide/eclipse/server/tests/util/TestCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.tests/src/org/cloudfoundry/ide/eclipse/server/tests/util/TestCallback.java
@@ -163,4 +163,9 @@ public class TestCallback extends CloudFoundryCallback {
 		// TODO Auto-generated method stub
 	}
 
+	@Override
+	public boolean confirmTheOperation(String title, String message) {
+		// ignore
+		return false;
+	}
 }

--- a/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/CloudFoundryUiCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/CloudFoundryUiCallback.java
@@ -234,4 +234,23 @@ public class CloudFoundryUiCallback extends CloudFoundryCallback {
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean confirmTheOperation(final String title, final String message) {
+		final boolean[] confirm = new boolean[1];
+		confirm[0] = false;
+		Display.getDefault().syncExec(new Runnable() {
+
+			public void run() {
+				confirm[0] = MessageDialog.openConfirm(
+						Display.getCurrent().getActiveShell(), 
+						title, 
+						message);
+			}
+
+		});
+		return confirm[0];
+	}
 }


### PR DESCRIPTION
...ject

**Phenomenon of the Bug:**
- During the process of deleting a bound project in Package Explorer, it will trigger all the other bound cloud applications to be re-pushed. The user can't do nothing except waiting all the re-pushing are finished.

![issue8_triggerrepushboundcloudapplication](https://cloud.githubusercontent.com/assets/7316500/4556609/2f8fc10c-4ecb-11e4-8515-a709649c0ca2.PNG)

**Effect of the Modifications:**
- The re-pushing still exists during the process of deleting bound project, but a confirmation dialog, which asks the user to determine whether to re-push or not, will be presented for each bound cloud application.
  By this way, the re-pushing can be interrupted and canceled by the dialog rather than be unbreakable.

![issue8_repushconfirm](https://cloud.githubusercontent.com/assets/7316500/4556605/261c343e-4ecb-11e4-9037-22ce25c5b321.PNG)
