### PR TITLE
Let user choose to delete bound cloud application or not when deleting l...

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryCallback.java
@@ -124,4 +124,13 @@ public abstract class CloudFoundryCallback {
 
 	}
 
+	/**
+	 * Shows a confirmation dialog with the given operation title and message, and
+	 * asks the user the determine whether to execute the target operation.
+	 * 
+	 * @param title the title of the target operation
+	 * @param message the message presented to the user
+	 * @return true if the user chooses to execute the target operation, false otherwise
+	 */
+	public abstract boolean confirmTheOperation(final String title, final String message);
 }

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryPlugin.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/CloudFoundryPlugin.java
@@ -218,6 +218,12 @@ public class CloudFoundryPlugin extends Plugin {
 			// TODO Auto-generated method stub
 
 		}
+
+		@Override
+		public boolean confirmTheOperation(String title, String message) {
+			// ignore
+			return false;
+		}
 	}
 
 	private static class AppStateTrackerEntry {

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.java
@@ -185,6 +185,10 @@ public class Messages extends NLS {
 
 	public static String ModuleResourceApplicationArchive_ERROR_NO_DEPLOYABLE_RES_FOUND;
 
+	public static String DELETE_CLOUD_APP_CONFIRMATION_TITLE;
+	
+	public static String DELETE_CLOUD_APP_CONFIRMATION_MESSAGE;
+
 	private static final String BUNDLE_NAME = CloudFoundryPlugin.PLUGIN_ID + ".internal.Messages"; //$NON-NLS-1$
 
 	static {

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.properties
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/Messages.properties
@@ -102,3 +102,5 @@ ROUTES=Getting routes for domain - {0}
 EMPTY_URL_ERROR=Enter a deployment URL
 JavaWebApplicationDelegate_ERROR_NO_MAPPED_APP_URL=No mapped application URLs set in application deployment information.
 ModuleResourceApplicationArchive_ERROR_NO_DEPLOYABLE_RES_FOUND=Unable to deploy module. No deployable resources found for module: {0} with id: {1}
+DELETE_CLOUD_APP_CONFIRMATION_TITLE=Delete cloud application
+DELETE_CLOUD_APP_CONFIRMATION_MESSAGE=Do you want to remove the bound application {0} from the server ?

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/ServerWorkingCopyFacade.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/ServerWorkingCopyFacade.java
@@ -1,0 +1,108 @@
+package org.cloudfoundry.ide.eclipse.server.core.internal;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IModuleType;
+import org.eclipse.wst.server.core.IServerWorkingCopy;
+import org.eclipse.wst.server.core.internal.ProgressUtil;
+import org.eclipse.wst.server.core.internal.Server;
+import org.eclipse.wst.server.core.internal.ServerWorkingCopy;
+
+/**
+ * Acts as a facade for an instance of <code>IServerWorkingCopy</code>.
+ * <p>
+ * Besides all functions of <code>IServerWorkingCopy</code>, it also provides
+ * the function to delete module just in the local server but not trigger the
+ * server delegate to delete the related cloud application in CF.
+ * 
+ * 
+ *
+ */
+@SuppressWarnings("restriction")
+public class ServerWorkingCopyFacade extends ServerWorkingCopy {
+
+	/**
+	 * Constructs an instance of <code>ServerWorkingCopyFacade</code>.
+	 * 
+	 * @param actualWC the actual <code>IServerWorkingCopy</code> instance to be facaded
+	 */
+	public ServerWorkingCopyFacade(IServerWorkingCopy actualWC) {
+		super((Server)actualWC.getOriginal());
+	}
+	
+	/**
+	 * Delete the given modules just in local server, and doesn't trigger the
+	 * server delegate to delete the cloud application in CF.
+	 * 
+	 * @param removes the modules to be removed locally
+	 * @param monitor the progress monitor
+	 * @throws CoreException error occurs when delete the given modules locally
+	 */
+	public void deleteModulesLocally(IModule[] removes, IProgressMonitor monitor) throws CoreException {
+		IStatus status = canModifyModules(null, removes, monitor);
+		if (status != null && status.getSeverity() == IStatus.ERROR)
+			throw new CoreException(status);
+		
+		try {
+			monitor = ProgressUtil.getMonitorFor(monitor);
+			monitor.subTask("Delete module locally");
+			
+			//<=>wch.setDirty(true);
+			Class<?> wchClazz = Class.forName("org.eclipse.wst.server.core.internal.WorkingCopyHelper");
+			Method setDirtyMethod = wchClazz.getDeclaredMethod("setDirty", boolean.class);
+			setDirtyMethod.setAccessible(true);
+			setDirtyMethod.invoke(wch, true);
+			
+			// trigger load of modules list
+			synchronized (modulesLock){
+				getModulesWithoutLock();
+				
+				if (removes != null) {
+					externalModules = getExternalModules();
+					for (IModule module : removes) {
+						if (modules.contains(module)) {
+							modules.remove(module);
+							resetState(new IModule[] { module }, monitor);
+						}
+						if (externalModules != null && externalModules.contains(module)) {
+							externalModules.remove(module);
+							resetState(new IModule[] { module }, monitor);
+						}
+					}
+				}
+				
+				// convert to attribute
+				List<String> list = new ArrayList<String>();
+				Iterator<IModule> iterator = modules.iterator();
+				while (iterator.hasNext()) {
+					IModule module = iterator.next();
+					StringBuffer sb = new StringBuffer(module.getName());
+					sb.append("::");
+					sb.append(module.getId());
+					IModuleType mt = module.getModuleType();
+					if (mt != null) {
+						sb.append("::");
+						sb.append(mt.getId());
+						sb.append("::");
+						sb.append(mt.getVersion());
+					}
+					list.add(sb.toString());
+				}
+				setAttribute(MODULE_LIST, list);
+			}
+
+			resetOptionalPublishOperations();
+			resetPreferredPublishOperations();
+		} catch (Exception e) {
+			throw new CoreException(new Status(IStatus.ERROR, CloudFoundryPlugin.PLUGIN_ID, 0, "" + e.getLocalizedMessage(), e));
+		}
+	}
+}

--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/DeleteModulesOperation.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/DeleteModulesOperation.java
@@ -102,6 +102,14 @@ public class DeleteModulesOperation extends AbstractDeploymentOperation {
 
 				this.cloudFoundryServerBehaviour.deleteApplication(application.getName(), monitor);
 
+				//Now the cloud application has been deleted successfully, 
+				//so the corresponding WST module can be deleted from
+				//the WST cloud server
+				if (appModule.getLocalModule() != null && !(appModule.getLocalModule() instanceof CloudFoundryApplicationModule)) {
+					cloudServer.deleteModulesLocally(new IModule[]{appModule.getLocalModule()}, monitor);
+				} else {
+					cloudServer.deleteModulesLocally(new IModule[]{appModule}, monitor);
+				}
 			}
 
 			CloudFoundryPlugin.getCallback().stopApplicationConsole(appModule, cloudServer);

--- a/org.cloudfoundry.ide.eclipse.server.tests/src/org/cloudfoundry/ide/eclipse/server/tests/util/TestCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.tests/src/org/cloudfoundry/ide/eclipse/server/tests/util/TestCallback.java
@@ -163,4 +163,10 @@ public class TestCallback extends CloudFoundryCallback {
 		// TODO Auto-generated method stub
 	}
 
+	@Override
+	public boolean confirmTheOperation(String title, String message) {
+		// ignore
+		return false;
+	}
+
 }

--- a/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/CloudFoundryUiCallback.java
+++ b/org.cloudfoundry.ide.eclipse.server.ui/src/org/cloudfoundry/ide/eclipse/server/ui/internal/CloudFoundryUiCallback.java
@@ -234,4 +234,22 @@ public class CloudFoundryUiCallback extends CloudFoundryCallback {
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean confirmTheOperation(final String title, final String message) {
+		final boolean[] confirm = new boolean[1];
+		confirm[0] = false;
+		Display.getDefault().syncExec(new Runnable() {
+			public void run() {
+				confirm[0] = MessageDialog.openQuestion(
+						Display.getCurrent().getActiveShell(), 
+						title, 
+						message);
+			}
+
+		});
+		return confirm[0];
+	}
 }


### PR DESCRIPTION
...ocal bound project

Currently:
- When delete a local project which has a bound cloud application:
![issue6_deleteaboundproject](https://cloud.githubusercontent.com/assets/7316500/4455260/0d97f17c-487d-11e4-8012-d27288d364b4.PNG)

- Ignoring whether to retain the contents of the hard disk or not, after pressing the 'OK' button, the project will be removed from current workspace, meanwhile the bound cloud application will be deleted quietly as well:
![issue6_theboundcloudapplicationdeletedquitely](https://cloud.githubusercontent.com/assets/7316500/4455295/87242ed4-487d-11e4-97c4-69fabfb5f3f7.PNG)

**Effect of the Modifications:**
- During the process of deleting the local bound project, a dialog will be presented to as user whether to delete the bound cloud application or not:
![issue6_modifiy_confirmtodeletecloudapplication](https://cloud.githubusercontent.com/assets/7316500/4455330/00bc37e6-487e-11e4-9d58-91168f4452fa.PNG)

- It will delete the related cloud application If choosing 'OK'. If 'Cancel' is chosen, It will refresh the application viewer and the cloud application will be shown as unbound:
![issue6_modifiy_refreshcloudapplication](https://cloud.githubusercontent.com/assets/7316500/4455335/0ec73912-487e-11e4-897f-594dcdaa72a6.PNG)