### PR TITLE
Proxy configuration : nonProxyHosts support

### DIFF
--- a/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryClientFactory.java
+++ b/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryClientFactory.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 Pivotal Software, Inc. 
- * 
+ * Copyright (c) 2012, 2015 Pivotal Software, Inc.
+ *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License, 
- * Version 2.0 (the "License"); you may not use this file except in compliance 
+ * are made available under the terms of the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -13,13 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *  
+ *
  *  Contributors:
  *     Pivotal Software, Inc. - initial API and implementation
  ********************************************************************************/
 package org.cloudfoundry.ide.eclipse.server.core.internal.client;
 
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.cloudfoundry.client.lib.CloudCredentials;
@@ -38,10 +39,10 @@ import org.eclipse.core.net.proxy.IProxyService;
  * or getting a list of organisations and spaces. Request wrappers do various
  * operations prior to invoking client API, including automatic client login and
  * proxy setting handling.
- * 
+ *
  * @see org.cloudfoundry.ide.eclipse.server.core.internal.client.ClientRequest
- * 
- * 
+ *
+ *
  */
 public class CloudFoundryClientFactory {
 
@@ -106,69 +107,37 @@ public class CloudFoundryClientFactory {
 		return new CloudCredentials(userName, password);
 	}
 
-	protected static String getNormalisedProtocol(String protocol) {
-		return protocol.toUpperCase();
-	}
-
 	public static HttpProxyConfiguration getProxy(URL url) {
-
-		// URL must be set and have a valid protocol in order to determine
-		// which proxy to use
-		if (url == null || url.getProtocol() == null) {
+		if (url == null) {
 			return null;
 		}
 		// In certain cases, the activator would have stopped and the plugin may
 		// no longer be available. Usually onl happens on shutdown.
-
 		CloudFoundryPlugin plugin = CloudFoundryPlugin.getDefault();
-
 		if (plugin != null) {
 			IProxyService proxyService = plugin.getProxyService();
+			if (proxyService != null) {
+				try {
+					IProxyData[] selectedProxies = proxyService.select(url.toURI());
 
-			// Only set proxies IF proxies are enabled (i.e a user has selected
-			// MANUAL provider configuration in network preferences. If it is
-			// direct,
-			// then skip proxy settings.
-			if (proxyService != null && proxyService.isProxiesEnabled()) {
-				IProxyData[] existingProxies = proxyService.getProxyData();
-
-				if (existingProxies != null) {
-
-					// Now determine the protocol to obtain the correct proxy
-					// type
-					String normalisedURLProtocol = getNormalisedProtocol(url.getProtocol());
-
-					// Resolve the correct proxy data type based on the URL
-					// protocol
-					String[] proxyDataTypes = { IProxyData.HTTP_PROXY_TYPE, IProxyData.HTTPS_PROXY_TYPE,
-							IProxyData.SOCKS_PROXY_TYPE };
-					String matchedProxyData = null;
-					for (String proxyDataType : proxyDataTypes) {
-						String normalised = getNormalisedProtocol(proxyDataType);
-						if (normalised.equals(normalisedURLProtocol)) {
-							matchedProxyData = proxyDataType;
-							break;
-						}
+					// No proxy configured or not found
+					if (selectedProxies == null || selectedProxies.length == 0) {
+						return null;
 					}
 
-					if (matchedProxyData != null) {
-						for (IProxyData data : existingProxies) {
-
-							if (matchedProxyData.equals(data.getType())) {
-								int proxyPort = data.getPort();
-								String proxyHost = data.getHost();
-								String user = data.getUserId();
-								String password = data.getPassword();
-								return proxyHost != null ? new HttpProxyConfiguration(proxyHost, proxyPort,
-										data.isRequiresAuthentication(), user, password) : null;
-							}
-						}
-					}
+					IProxyData data = selectedProxies[0];
+					int proxyPort = data.getPort();
+					String proxyHost = data.getHost();
+					String user = data.getUserId();
+					String password = data.getPassword();
+					return proxyHost != null ? new HttpProxyConfiguration(proxyHost, proxyPort,
+							data.isRequiresAuthentication(), user, password) : null;
+				}
+				catch (URISyntaxException e) {
+					// invalid url (protocol, ...) => proxy will be null
 				}
 			}
 		}
-
 		return null;
-
 	}
 }


### PR DESCRIPTION
Hi, 

Currently the v1.8.2 doesn't support the **nonProxyHosts** network configuration.
Mainly because [CloudFoundryClientFactory.getProxy()](https://github.com/cloudfoundry/eclipse-integration-cloudfoundry/blob/master/org.cloudfoundry.ide.eclipse.server.core/src/org/cloudfoundry/ide/eclipse/server/core/internal/client/CloudFoundryClientFactory.java#L145) applies the proxy only if activated and protocol found.

**Impacts** : When you are using an intranet CF, you need to switch to the _Direct_ network provider for every CF function. It is boring ;-).

This PR provides the usage of [IProxyService.select(URI uri)](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fcore%2Fnet%2Fproxy%2FIProxyService.html), doing the job for us.

NB : I can't sign [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) / [corporations](http://www.cloudfoundry.org/corpcontribution.pdf) , links broken, sorry.
Best regards.
